### PR TITLE
Fix `get_edatools` import

### DIFF
--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -9,7 +9,11 @@ import shutil
 import warnings
 
 import yaml
-from edalize import get_edatools
+
+try:
+    from edalize.edatool import get_edatools
+except ImportError:
+    from edalize import get_edatools
 
 from fusesoc import utils
 from fusesoc.capi2.exprs import Exprs

--- a/fusesoc/capi2/core.py
+++ b/fusesoc/capi2/core.py
@@ -47,6 +47,11 @@ class Genparams(dict):
     pass
 
 
+class Any:
+    def __new__(self, thing):
+        return thing
+
+
 class StringWithUseFlags(str):
     """ A parsed string with support for use flags. """
 
@@ -126,7 +131,11 @@ class Section:
                         _d[_name] = globals()[self.dicts[k]](_items)
                     except AttributeError as e:
                         raise SyntaxError(f"Bad option '{_name}' in section '{k}'")
-                    setattr(_d[_name], "name", _name)
+                    try:
+                        setattr(_d[_name], "name", _name)
+                    except AttributeError:
+                        # e.g. bool objects can't set a "name" attribute
+                        pass
                 setattr(self, k, _d)
             else:
                 logger.warning(
@@ -278,6 +287,19 @@ class Core:
                         hooks[hook].append(self.scripts[script])
 
         return hooks
+
+    """ Get flags, including tool, from target """
+
+    def get_flags(self, target_name):
+        flags = {}
+        target = self.targets.get(target_name)
+
+        if target:
+            flags = target.flags.copy()
+            # Special case for tool as we get it from default_tool
+            if target.default_tool:
+                flags["tool"] = str(target.default_tool)
+        return flags
 
     def get_scripts(self, files_root, flags):
         self._debug("Getting hooks for flags '{}'".format(str(flags)))
@@ -807,6 +829,10 @@ Target:
     - name : vpi
       type : StringWithUseFlags
       desc : VPI modules to build and include for target
+  dicts:
+    - name : flags
+      type : Any
+      desc : Default values of flags
 
 Tools:
   description : The valid subsections of the Tools section and their options are defined by what Edalize backends are available at runtime. The sections listed here are the ones that were available when the documentation was generated.

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -392,7 +392,9 @@ def run(cm, args):
         do_build = args.build
         do_run = args.run
 
-    flags = {"tool": args.tool, "target": args.target}
+    flags = {"target": args.target or "default"}
+    if args.tool:
+        flags["tool"] = args.tool
     for flag in args.flag:
         if flag[0] == "+":
             flags[flag[1:]] = True
@@ -433,15 +435,19 @@ def run_backend(
         "No tool was supplied on command line or found in '{}' core description"
     )
     core = _get_core(cm, system)
+
+    target = flags["target"]
     try:
-        tool = core.get_tool(flags)
+        flags = dict(core.get_flags(target), **flags)
     except SyntaxError as e:
         logger.error(str(e))
         exit(1)
+
+    tool = flags["tool"]
+
     if not tool:
         logger.error(tool_error.format(system))
         exit(1)
-    flags["tool"] = tool
     build_root = build_root_arg or os.path.join(
         cm.config.build_root, core.name.sanitized_name
     )
@@ -710,7 +716,7 @@ def get_parser():
     parser_library_add.add_argument(
         "--global",
         action="store_true",
-        help="Use the global FuseSoc config file in $XDG_CONFIG_HOME/fusesoc/fusesoc.conf",
+        help="Use the global FuseSoC config file in $XDG_CONFIG_HOME/fusesoc/fusesoc.conf",
     )
     parser_library_add.set_defaults(func=add_library)
 

--- a/fusesoc/main.py
+++ b/fusesoc/main.py
@@ -21,7 +21,10 @@ if os.path.exists(os.path.join(fusesocdir, "fusesoc")):
 
 import logging
 
-from edalize import get_edatool
+try:
+    from edalize.edatool import get_edatool
+except ImportError:
+    from edalize import get_edatool
 
 from fusesoc.config import Config
 from fusesoc.coremanager import CoreManager, DependencyError


### PR DESCRIPTION
## Motivation
The latest version of Edalize moved the `get_edatools` from `edalize` to `edalize.edatool`, breaking the compatibility with old versions of FuseSoC, including the `ot` branch in Opentitan's fork.

> Opentitan's `master` branch breaks compatibility with some Opentitan's HDL modules imported in `x-heep` using Vendor. Therefore, a switch to such version is not straightforward.

## Proposed solution
Modify the `import` statements in FuseSoC to take into account the change above, as already done in Opentitan's `master` branch ([here](https://github.com/lowRISC/fusesoc/blob/58bbb864723112e9bfd7e02a17749800225815e9/fusesoc/main.py#L25)).

## Bonus
This pull request also integrates the changes required to support `flags` defined inside a `target` in a `.core` file, besides those defined in the CLI.